### PR TITLE
Use the right dash for GitLab Snippets. Add bentobox.io to manuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Community driven list of useful things for front-end developers. [How to contrib
 - [Dabblet](http://dabblet.com) — interactive playground for quickly testing snippets of CSS and HTML
 - [JSBin](http://jsbin.com) — JavaScript, HTML and CSS playground
 - [gist.github](https://gist.github.com) — code snippets
-- [GitLab Snippets](https://gitlab.com/snippets) - code snippets
+- [GitLab Snippets](https://gitlab.com/snippets) — code snippets
 - [JSFiddle](http://jsfiddle.net) — JavaScript, HTML and CSS playground
 - [CodePen](http://codepen.io) — Another JS, HTML, CSS sandbox
 - [RegExr](http://gskinner.com/RegExr/) — regular expression playground
@@ -249,6 +249,7 @@ Community driven list of useful things for front-end developers. [How to contrib
 - [dochub.io](http://dochub.io) — CSS, HTML, JavaScript, DOM, jQuery, PHP, Python
 - [devdocs.io](http://devdocs.io) — HTML, CSS, DOM, DOM Events, JavaScript, jQuery
 - [overapi.com](http://overapi.com) — Collecting All Cheat Sheets
+- [Bento](http://www.bentobox.io/) — Everything you need to know about web development. Neatly packaged.
 - [Superherojs.com](http://superherojs.com/) - This site is a continuously updated list of articles that help explain the syntax of JavaScript, how to organize your projects, how to test your code, and what's on the horizon.
 - [JSBooks](http://jsbooks.revolunet.com/) - JSBooks the best free JavaScript books/resources
 - [WebPlatform.org](http://www.webplatform.org/) - Open community of developers building resources for a better web, regardless of brand, browser or platform


### PR DESCRIPTION
used "-" instead of "—" in my last pull request so I've fixed that and added one more manual link.
