### PR TITLE
Add SCSS-Lint as a quality tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ Community driven list of useful things for front-end developers. [How to contrib
 - [W3C CSS Validator](http://jigsaw.w3.org/css-validator)
 - [CSSLint](http://csslint.net) — static analysis tool for CSS code
 - [RECSS](http://twitter.github.com/recess) — A simple and attractive code quality tool for CSS built on top of LESS
+- [SCSS-Lint](https://github.com/mariusbuescher/frontdesk.git) - Configurable tool for writing clean and consistent SCSS
 - [JSLint](http://jslint.com) — The JavaScript Code Quality Tool by Douglas Crockford
 - [JSHint](http://jshint.com) — community-driven tool to detect errors and potential problems in JavaScript code
 - [JSCS](https://github.com/mdevils/node-jscs) — JavaScript Code Style checker


### PR DESCRIPTION
I would love to see SCSS-Lint in the Quality Tools Section as it is like RECSS for SCSS.